### PR TITLE
Precompile requestjs.js

### DIFF
--- a/lib/requestjs/engine.rb
+++ b/lib/requestjs/engine.rb
@@ -2,7 +2,7 @@ module Requestjs
   class Engine < ::Rails::Engine
     initializer "requestjs.assets" do
       if Rails.application.config.respond_to?(:assets)
-        Rails.application.config.assets.precompile += %w( rails-requestjs )
+        Rails.application.config.assets.precompile += %w( rails-requestjs requestjs )
       end
     end
 


### PR DESCRIPTION
As mentioned in #5 the precompile for `requestjs.js` is missing in v0.0.7:
> Asset requestjs.js was not declared to be precompiled in production etc.