### PR TITLE
Importmaps: pin `@rails.request.js` instead of `@rails.requestjs` 

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,1 @@
+pin "@rails/request.js", to: "requestjs.js"

--- a/lib/install/requestjs_with_asset_pipeline.rb
+++ b/lib/install/requestjs_with_asset_pipeline.rb
@@ -4,4 +4,4 @@ APP_JS_PATH = APP_JS_ROOT.exist? ? APP_JS_ROOT : Rails.root.join("app/javascript
 create_file Rails.root.join("app/javascript/application.js") unless APP_JS_PATH.exist?
 
 say "Import Request.JS in existing #{APP_JS_PATH}"
-append_to_file APP_JS_PATH.join("application.js"), %(import "@rails/requestjs"\n)
+append_to_file APP_JS_PATH.join("application.js"), %(import "@rails/request.js"\n)

--- a/lib/requestjs/engine.rb
+++ b/lib/requestjs/engine.rb
@@ -6,12 +6,8 @@ module Requestjs
       end
     end
 
-    initializer "requestjs.importmap" do
-      if Rails.application.respond_to?(:importmap)
-        Rails.application.importmap.draw do
-          pin "@rails/requestjs", to: "requestjs.js"
-        end
-      end
+    initializer "requestjs.importmap", before: "importmap" do |app|
+      app.config.importmap.paths << Engine.root.join("config/importmap.rb")
     end
   end
 end

--- a/lib/requestjs/engine.rb
+++ b/lib/requestjs/engine.rb
@@ -2,7 +2,7 @@ module Requestjs
   class Engine < ::Rails::Engine
     initializer "requestjs.assets" do
       if Rails.application.config.respond_to?(:assets)
-        Rails.application.config.assets.precompile += %w( rails-requestjs requestjs )
+        Rails.application.config.assets.precompile += %w( rails-requestjs.js requestjs.js )
       end
     end
 


### PR DESCRIPTION
Basically following what `importmap-rails` suggests here https://github.com/rails/importmap-rails#composing-import-maps and pinning Request.JS to be the same way to import it in a JS file as we do when installed with webpacker.

